### PR TITLE
Feat/simplied menu constructor

### DIFF
--- a/Data/CustomOptionsMenu.cs
+++ b/Data/CustomOptionsMenu.cs
@@ -8,6 +8,11 @@ namespace MenuCore
         public string menuName;
         public List<MenuItem> menuItems = new List<MenuItem>();
 
+        public CustomOptionsMenu(string name = null)
+        {
+            menuName = name;
+        }
+
         /// <summary>
         /// Creates a slider
         /// </summary>

--- a/MenuCore.csproj
+++ b/MenuCore.csproj
@@ -1,6 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="packages\Obfuscar.2.2.30\build\obfuscar.props" Condition="Exists('packages\Obfuscar.2.2.30\build\obfuscar.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -125,6 +124,5 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('packages\Obfuscar.2.2.30\build\obfuscar.props')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Obfuscar.2.2.30\build\obfuscar.props'))" />
   </Target>
 </Project>

--- a/Plugin.cs
+++ b/Plugin.cs
@@ -7,6 +7,7 @@ using System.Reflection;
 namespace MenuCore
 {
     [BepInPlugin(PluginInfo.PLUGIN_GUID, PluginInfo.PLUGIN_NAME, PluginInfo.PLUGIN_VERSION)]
+    [BepInDependency("com.steven.nasb.moddingutils")]
     class Plugin : BaseUnityPlugin
     {
         internal static Plugin Instance;


### PR DESCRIPTION
Added a constructor that allows you to pass in the name of the options menu.

![image](https://user-images.githubusercontent.com/9684760/140009037-c8610ce1-5194-40b6-ae97-ac04cdb84350.png)

So you can do

```cs
var menu = new CustomOptionsMenu("mod name");
```
instead of
```cs
var menu = new CustomOptionsMenu();
menu.MenuName = "mod name";
```
